### PR TITLE
Swap windows

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -58,9 +58,9 @@ local latestMove = {
   stepY = -1,
 }
 
-function obj:move(unit) self:moveWindow(self.hs.window.focusedWindow(), unit) end
+function obj:move(unit) self.hs.window.focusedWindow():move(unit, nil, true, 0) end
 
-function obj:moveWindow(window, unit) window:move(unit, nil, true, 0) end
+function obj:moveWindow(windowId, unit) self.hs.window.get(windowId):move(unit, nil, true, 0) end
 
 function obj:swap()
   if latestMove.windowId == -1 then
@@ -70,12 +70,11 @@ function obj:swap()
   local window = self.hs.window.focusedWindow():frame()
   local x, y, w, h = window.x, window.y, window.w, window.h
 
-  local pWindow = self.hs.window.get(latestMove.windowId)
-  local pFrame = pWindow:frame()
-  local pWindowX, pWindowY, pWindowW, pWindowH = pFrame.x, pFrame.y, pFrame.w, pFrame.h
+  local pWindow = self.hs.window.get(latestMove.windowId):frame()
+  local pWindowX, pWindowY, pWindowW, pWindowH = pWindow.x, pWindow.y, pWindow.w, pWindow.h
 
   self:move({ x = pWindowX, y = pWindowY, w = pWindowW, h = pWindowH })
-  self:moveWindow(pWindow, { x = x, y = y, w = w, h = h })
+  self:moveWindow(latestMove.windowId, { x = x, y = y, w = w, h = h })
 end
 
 function obj:moveWithCycles(unitFn)

--- a/init.lua
+++ b/init.lua
@@ -102,7 +102,7 @@ function obj:swap()
 end
 
 function obj:showOverlayText(window, text)
-  local elem = self.hs.styledtext.new(text, {font={name="Impact", size=60}, color=self.hs.drawing.color.x11.crimson})
+  local elem = self.hs.styledtext.new(text, {font={name="Helvetica", size=60}, color=self.hs.drawing.color.x11.crimson})
   local frame = self.hs.geometry.rect(window.x + 120, window.y + 60, 60, 60)
 
   local draw = self.hs.drawing.text(frame, elem)

--- a/init.lua
+++ b/init.lua
@@ -30,6 +30,7 @@ obj.mapping = {
   toggleFullScreen = { obj.mash, 'f' },
   toggleZoom = { obj.mash, 'z' },
   center = { obj.mash, 'c' },
+  swap = { obj.mash, 's' },
   nextScreen = { obj.mash, 'n' },
   previousScreen = { obj.mash, 'p' },
   resizeOut = { obj.mash, '=' },
@@ -57,7 +58,25 @@ local latestMove = {
   stepY = -1,
 }
 
-function obj:move(unit) self.hs.window.focusedWindow():move(unit, nil, true, 0) end
+function obj:move(unit) self:moveWindow(self.hs.window.focusedWindow(), unit) end
+
+function obj:moveWindow(window, unit) window:move(unit, nil, true, 0) end
+
+function obj:swap()
+  if latestMove.windowId == -1 then
+    return
+  end
+
+  local window = self.hs.window.focusedWindow():frame()
+  local x, y, w, h = window.x, window.y, window.w, window.h
+
+  local pWindow = self.hs.window.get(latestMove.windowId)
+  local pFrame = pWindow:frame()
+  local pWindowX, pWindowY, pWindowW, pWindowH = pFrame.x, pFrame.y, pFrame.w, pFrame.h
+
+  self:move({ x = pWindowX, y = pWindowY, w = pWindowW, h = pWindowH })
+  self:moveWindow(pWindow, { x = x, y = y, w = w, h = h })
+end
 
 function obj:moveWithCycles(unitFn)
   local windowId = self.hs.window.focusedWindow():id()
@@ -228,6 +247,7 @@ function obj:bindHotkeys(mapping)
   end)
   self.hs.hotkey.bind(self.mapping.toggleZoom[1], self.mapping.toggleZoom[2], function() self:toggleZoom() end)
   self.hs.hotkey.bind(self.mapping.center[1], self.mapping.center[2], function() self:center() end)
+  self.hs.hotkey.bind(self.mapping.swap[1], self.mapping.swap[2], function() self:swap() end)
   self.hs.hotkey.bind(self.mapping.nextScreen[1], self.mapping.nextScreen[2], function() self:nextScreen() end)
   self.hs.hotkey.bind(self.mapping.previousScreen[1], self.mapping.previousScreen[2], function() self:prevScreen() end)
   self.hs.hotkey.bind(self.mapping.resizeOut[1], self.mapping.resizeOut[2], function() self:resizeOut() end)

--- a/init.lua
+++ b/init.lua
@@ -64,7 +64,8 @@ local swapPair = {
 }
 
 function obj:swap()
-  unassign = function () 
+  local currentWindow = self.hs.window.focusedWindow():frame()
+  local unassign = function ()
     swapPair.a = -1
     swapPair.b = -1
     self:showOverlayText(currentWindow, "Ø")
@@ -76,7 +77,6 @@ function obj:swap()
   end
 
   local windowId = self.hs.window.focusedWindow():id()
-  local currentWindow = self.hs.window.focusedWindow():frame()
 
   local isUnassignAction = (swapPair.a ~= -1 and swapPair.a == windowId)
   if isUnassignAction then

--- a/init.lua
+++ b/init.lua
@@ -75,7 +75,7 @@ function obj:swap()
     return
   end
 
-  local isAssignFirstAction = swapPair.a == -1 or swapPair.a == windowId 
+  local isAssignFirstAction = swapPair.a == -1 or swapPair.a == windowId
   if isAssignFirstAction then
     swapPair.a = windowId
     self:showOverlayText(currentWindow, "A")
@@ -104,12 +104,12 @@ end
 function obj:showOverlayText(window, text)
   local elem = self.hs.styledtext.new(text, {font={name="Impact", size=60}, color=self.hs.drawing.color.x11.crimson})
   local frame = self.hs.geometry.rect(window.x + 120, window.y + 60, 60, 60)
-  
+
   local draw = self.hs.drawing.text(frame, elem)
   draw:setLevel(self.hs.drawing.windowLevels.overlay)
   draw:show()
-  
-  timer = self.hs.timer.doAfter(0.5, function() draw:delete() draw=nil end)
+
+  self.hs.timer.doAfter(0.5, function() draw:delete() draw=nil end)
 end
 
 function obj:move(unit) self.hs.window.focusedWindow():move(unit, nil, true, 0) end

--- a/init.lua
+++ b/init.lua
@@ -64,14 +64,23 @@ local swapPair = {
 }
 
 function obj:swap()
-  local windowId = self.hs.window.focusedWindow():id()
-  local currentWindow = self.hs.window.focusedWindow():frame()
-
-  local isUnassignAction = swapPair.a ~= -1 and swapPair.a == windowId
-  if isUnassignAction then
+  unassign = function () 
     swapPair.a = -1
     swapPair.b = -1
     self:showOverlayText(currentWindow, "Ø")
+  end
+
+  local focusedWindow = self.hs.window.focusedWindow()
+  if focusedWindow == nil then
+    return
+  end
+
+  local windowId = self.hs.window.focusedWindow():id()
+  local currentWindow = self.hs.window.focusedWindow():frame()
+
+  local isUnassignAction = (swapPair.a ~= -1 and swapPair.a == windowId)
+  if isUnassignAction then
+    unassign()
     return
   end
 
@@ -89,19 +98,31 @@ function obj:swap()
     return
   end
 
-  local a = self.hs.window.get(swapPair.a):frame()
-  local b = self.hs.window.get(swapPair.b):frame()
-  self:showOverlayText(a, "A")
-  self:showOverlayText(b, "B")
+
+  local aWindow = self.hs.window.get(swapPair.a)
+  local bWindow = self.hs.window.get(swapPair.b)
+  if aWindow == nil or bWindow == nil then
+    unassign()
+    return
+  end
+
+  local a = aWindow:frame()
+  local b = bWindow:frame()
 
   local aCoords = { x = a.x, y = a.y, w = a.w, h = a.h }
   local bCoords = { x = b.x, y = b.y, w = b.w, h = b.h }
 
   self:moveWindow(swapPair.a, bCoords)
   self:moveWindow(swapPair.b, aCoords)
+  self:showOverlayText(a, "A")
+  self:showOverlayText(b, "B")
 end
 
 function obj:showOverlayText(window, text)
+  if window == nil then
+    window = hs.screen.mainScreen():frame()
+  end
+
   local elem = self.hs.styledtext.new(text, {font={name="Helvetica", size=60}, color=self.hs.drawing.color.x11.crimson})
   local frame = self.hs.geometry.rect(window.x + 120, window.y + 60, 60, 60)
 

--- a/init.lua
+++ b/init.lua
@@ -62,21 +62,6 @@ function obj:move(unit) self.hs.window.focusedWindow():move(unit, nil, true, 0) 
 
 function obj:moveWindow(windowId, unit) self.hs.window.get(windowId):move(unit, nil, true, 0) end
 
-function obj:swap()
-  if latestMove.windowId == -1 then
-    return
-  end
-
-  local window = self.hs.window.focusedWindow():frame()
-  local x, y, w, h = window.x, window.y, window.w, window.h
-
-  local pWindow = self.hs.window.get(latestMove.windowId):frame()
-  local pWindowX, pWindowY, pWindowW, pWindowH = pWindow.x, pWindow.y, pWindow.w, pWindow.h
-
-  self:move({ x = pWindowX, y = pWindowY, w = pWindowW, h = pWindowH })
-  self:moveWindow(latestMove.windowId, { x = x, y = y, w = w, h = h })
-end
-
 function obj:moveWithCycles(unitFn)
   local windowId = self.hs.window.focusedWindow():id()
   local sameMoveAction = latestMove.windowId == windowId and latestMove.direction == unitFn
@@ -192,6 +177,21 @@ function obj:center()
   self.hs.window.focusedWindow():centerOnScreen(nil, true, 0)
  end
 
+function obj:swap()
+  if latestMove.windowId == -1 then
+    return
+  end
+
+  local window = self.hs.window.focusedWindow():frame()
+  local x, y, w, h = window.x, window.y, window.w, window.h
+
+  local pWindow = self.hs.window.get(latestMove.windowId):frame()
+  local pWindowX, pWindowY, pWindowW, pWindowH = pWindow.x, pWindow.y, pWindow.w, pWindow.h
+
+  self:move({ x = pWindowX, y = pWindowY, w = pWindowW, h = pWindowH })
+  self:moveWindow(latestMove.windowId, { x = x, y = y, w = w, h = h })
+end
+
 function obj:nextScreen()
   self.hs.window.focusedWindow():moveToScreen(self.hs.window.focusedWindow():screen():next(), false, true, 0)
 end
@@ -222,6 +222,7 @@ function obj:resizeIn() self:resizeWindowInSteps(false) end
 ---   * toggleFullScreen
 ---   * toggleZoom
 ---   * center
+---   * swap
 ---   * nextScreen
 ---   * previousScreen
 ---   * resizeOut

--- a/init_test.lua
+++ b/init_test.lua
@@ -20,7 +20,7 @@ function TestShiftIt.testBindDefault()
     local expected = {
         'left', 'right', 'up', 'down',
         '1', '2', '3', '4', 'm',
-        'f', 'z', 'c', 'n', 'p', 's',
+        'f', 'z', 'c', 's', 'n', 'p', 
         '=', '-',
     }
     for i, item in pairs(expected) do
@@ -41,7 +41,7 @@ function TestShiftIt.testBindOverrideVimKeys()
     local expected = {
         'h', 'l', 'k', 'j',
         '1', '2', '3', '4', 'm',
-        'f', 'z', 'c', 'n', 'p', 's',
+        'f', 'z', 'c', 's', 'n', 'p',
         '=', '-',
     }
     for i, item in pairs(expected) do

--- a/init_test.lua
+++ b/init_test.lua
@@ -20,7 +20,7 @@ function TestShiftIt.testBindDefault()
     local expected = {
         'left', 'right', 'up', 'down',
         '1', '2', '3', '4', 'm',
-        'f', 'z', 'c', 's', 'n', 'p', 
+        'f', 'z', 'c', 's', 'n', 'p',
         '=', '-',
     }
     for i, item in pairs(expected) do

--- a/init_test.lua
+++ b/init_test.lua
@@ -15,12 +15,12 @@ end
 
 function TestShiftIt.testBindDefault()
     shiftit:bindHotkeys({})
-    lu.assertEquals(#hsmocks.hotkey.bindings, 16)
+    lu.assertEquals(#hsmocks.hotkey.bindings, 17)
 
     local expected = {
         'left', 'right', 'up', 'down',
         '1', '2', '3', '4', 'm',
-        'f', 'z', 'c', 'n', 'p',
+        'f', 'z', 'c', 'n', 'p', 's',
         '=', '-',
     }
     for i, item in pairs(expected) do
@@ -36,12 +36,12 @@ function TestShiftIt.testBindOverrideVimKeys()
         up = { { 'ctrl', 'alt', 'cmd' }, 'k' },
         right = { { 'ctrl', 'alt', 'cmd' }, 'l' },
     })
-    lu.assertEquals(#hsmocks.hotkey.bindings, 16)
+    lu.assertEquals(#hsmocks.hotkey.bindings, 17)
 
     local expected = {
         'h', 'l', 'k', 'j',
         '1', '2', '3', '4', 'm',
-        'f', 'z', 'c', 'n', 'p',
+        'f', 'z', 'c', 'n', 'p', 's',
         '=', '-',
     }
     for i, item in pairs(expected) do


### PR DESCRIPTION
A function that swaps two windows.

The issue i'm solving is the following:
- My screen on the left is big, and I don't like turning my head to the left :D 
- I have two windows there, one of them is usually in my focus, and then another one. Like a debug panel and a console.

Implementation:
- Select a window and hit mesh+s, save the window ID
- Select another window. mesh+s will now swap it with the first one
- Hitting mesh+s on the first window, removes the saved ID and resets the swapping pair